### PR TITLE
Fix invalid rate limit 

### DIFF
--- a/src/mod_site.rs
+++ b/src/mod_site.rs
@@ -254,7 +254,7 @@ where
                 if retries >= 5 {
                     return Err(ferinth::Error::RateLimitExceeded(delay_sec));
                 }
-                log::warn!("Retrying request in {} due to rate limit", delay_sec);
+                log::warn!("Retrying request in {} sec due to rate limit", delay_sec);
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_sec as u64)).await;
                 retries += 1;
             }

--- a/src/mod_site.rs
+++ b/src/mod_site.rs
@@ -254,7 +254,7 @@ where
                 if retries >= 5 {
                     return Err(ferinth::Error::RateLimitExceeded(delay_sec));
                 }
-                log::warn!("Retrying request due to rate limit");
+                log::warn!("Retrying request in {} due to rate limit", delay_sec);
                 tokio::time::sleep(tokio::time::Duration::from_secs(delay_sec as u64)).await;
                 retries += 1;
             }

--- a/src/mod_site.rs
+++ b/src/mod_site.rs
@@ -256,7 +256,7 @@ where
                     return Err(ferinth::Error::RateLimitExceeded(delay_sec));
                 }
                 log::warn!("Retrying request in {} (+ {}) sec due to rate limit", delay_sec, adjusted_delay - delay_sec as u64);
-                tokio::time::sleep(tokio::time::Duration::from_secs(adjusted_delay as u64)).await;
+                tokio::time::sleep(tokio::time::Duration::from_secs(adjusted_delay)).await;
                 retries += 1;
             }
             Err(e) => return Err(e),


### PR DESCRIPTION
Sometimes the server returns "0" as a rate limit, this PR sets a minimum time to wait for the rate limit. It also improves the rate limit log.